### PR TITLE
fix issue with pagination

### DIFF
--- a/pulumi-cloud-import-aws/main.go
+++ b/pulumi-cloud-import-aws/main.go
@@ -195,7 +195,7 @@ func buildImportSpec(ctx *pulumi.Context, mode Mode) (importFile, error) {
 								importChan <- resource
 							}
 						}
-						return false
+						return true
 					})
 
 				// just print out errors as info for now


### PR DESCRIPTION
I introduced this 'bug' in my last commit. Paginator should return true when it needs more pages.

Nonetheless CC API seems to ignore the pagination config for most of the types. For instance, it'd return all s3 buckets in your account even if you request 1, making this bug irrelevant - but lets get pagination right.